### PR TITLE
Fixed the logic on is_confirm() and is_lock_expired(), they were the reve

### DIFF
--- a/classes/warden/model/user.php
+++ b/classes/warden/model/user.php
@@ -477,7 +477,7 @@ SQL;
      */
     public function is_confirmation_required()
     {
-        return !$this->is_confirmed();
+        return $this->is_confirmed();
     }
 
     /**
@@ -660,7 +660,7 @@ SQL;
      */
     public function is_access_locked()
     {
-        return !$this->is_lock_expired();
+        return $this->is_lock_expired();
     }
 
     /**


### PR DESCRIPTION
Fixed the logic on is_confirm() and is_lock_expired(), they were the reverse of what they should be. When I registered a brand new user with confirmable turned off in the config, and using the default lock time from the class it first threw an error saying "confirmable_token" property not found. 

After switching the logic there, it told me the account was locked upon first authentication.

I tested it by calling lock_access() on the newly created user after fixing this logic.
