### PR TITLE
Fixed some Login Issues with fuelPHP 1.2

### DIFF
--- a/classes/warden.php
+++ b/classes/warden.php
@@ -533,7 +533,7 @@ class Warden
      */
     public static function generate_token()
     {
-        $token = join(':', array(Str::random('alnum', 15), time()));
+        $token = join(':', array(\Str::random('alnum', 15), time()));
         return str_replace(
 	        array('+', '/', '=', 'l', 'I', 'O', '0'), 
 	        array('p', 'q', 'r', 's', 'x', 'y', 'z'), 

--- a/classes/warden/driver.php
+++ b/classes/warden/driver.php
@@ -156,7 +156,7 @@ class Warden_Driver
         {
             if ($remember === true) {
                 // Set token data
-                $user->remember_token = Warden::generate_token();
+                $user->remember_token = Warden::forge()->generate_token();
 
                 // Set the remember-me cookie
                 \Cookie::set('remember_token',
@@ -301,7 +301,7 @@ class Warden_Driver
     protected function complete_login(Model_User $user)
     {
         // Create and set new authentication token
-        $user->authentication_token = Warden::generate_token();
+        $user->authentication_token = Warden::forge()->generate_token();
 
         try {
             if ($this->config['trackable'] === true) {

--- a/classes/warden/driver.php
+++ b/classes/warden/driver.php
@@ -156,7 +156,7 @@ class Warden_Driver
         {
             if ($remember === true) {
                 // Set token data
-                $user->remember_token = Warden::instance()->generate_token();
+                $user->remember_token = Warden::generate_token();
 
                 // Set the remember-me cookie
                 \Cookie::set('remember_token',
@@ -301,7 +301,7 @@ class Warden_Driver
     protected function complete_login(Model_User $user)
     {
         // Create and set new authentication token
-        $user->authentication_token = Warden::instance()->generate_token();
+        $user->authentication_token = Warden::generate_token();
 
         try {
             if ($this->config['trackable'] === true) {

--- a/classes/warden/model/user.php
+++ b/classes/warden/model/user.php
@@ -213,7 +213,7 @@ class Model_User extends \Orm\Model
 		if (is_int($username_or_email_or_id)) {
 			$record = static::find($username_or_email_or_id);
 		} else {
-	        $username_or_email = \DB::escape(\Str::lower($username_or_email));
+	        $username_or_email = \DB::escape(\Str::lower($username_or_email_or_id));
 	
 	        $table = static::table();
 	        $properties = implode('`, `', array_keys(static::properties()));


### PR DESCRIPTION
I ran into some serious issues when I went to test the login functionality.

Warden::instance()->function() was throwing errors, so I just went back to Warden::function() - not sure if that matters for what was happening (generating a token). 

Warden main class wasn't referncing the Str class properly (needed \Str).

User Model had a variable mis-label that made logins impossible.

Let me know if some of them affect anything else, but they all worked in my testing so far.
